### PR TITLE
Auth select params

### DIFF
--- a/src/commplugin.rs
+++ b/src/commplugin.rs
@@ -19,3 +19,14 @@ pub struct StartCommResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attr_url: Option<String>,
 }
+
+/// Parameters expected by the auth-select widget
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AuthSelectParams {
+    /// The session purpose
+    pub purpose: String,
+    /// The start url to redirect the user to on authentication success
+    pub start_url: String,
+    /// The communication method's display name
+    pub display_name: String,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,5 @@ mod common;
 
 pub use authplugin::{StartAuthRequest, StartAuthResponse};
 pub use authresult::{AuthResult, AuthStatus, SessionActivity};
-pub use commplugin::{StartCommRequest, StartCommResponse};
+pub use commplugin::{StartCommRequest, StartCommResponse, AuthSelectParams};
 pub use common::{SessionOptions, StartRequestAuthOnly, ClientUrlResponse};


### PR DESCRIPTION
Add struct for AuthSelectParams, describing what is needed to make the auth-select menu work. Useful in communication plugins that support authentication during communication
